### PR TITLE
fix transocder filter generation

### DIFF
--- a/grpc-transcoder/main.go
+++ b/grpc-transcoder/main.go
@@ -36,8 +36,7 @@ spec:
     filterName: envoy.grpc_json_transcoder
     filterType: HTTP
     filterConfig:
-      protoDescriptorBin: !!binary |
-        {{ .DescriptorBinary }}
+      protoDescriptorBin: {{ .DescriptorBinary }}
       services: {{ range .ProtoServices }} 
       - {{ . }}{{end}}
 ---`))


### PR DESCRIPTION
protobuf type `bytes` expect base64 encoded string from json, do not encode it as binary.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>